### PR TITLE
BUG-975 - Using NSLog instead of throwing error with unexpected HKWorkoutActivityType 

### DIFF
--- a/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
+++ b/RCTAppleHealthKit/RCTAppleHealthKit+Utils.m
@@ -447,11 +447,9 @@
         case HKWorkoutActivityTypeHandCycling:
             return @"HandCycling";
         default:{
-            NSException *e = [NSException
-                              exceptionWithName:@"HKWorkoutActivityType InvalidValue"
-                              reason:@"HKWorkoutActivityType can only have a value from the HKWorkoutActivityType enum"
-                              userInfo:nil];
-            @throw e;
+            NSString *errorMsg = [NSString stringWithFormat: @"HKWorkoutActivityType %d can only have a value from the HKWorkoutActivityType enum", enumValue];
+            NSLog(@"%@",errorMsg);
+            return @"Unknown";
         }
     }
 }


### PR DESCRIPTION
The library is throwing an error when an unknown activity is retrieved. Throwing an error seems a bit radical.

This PR replaces the throw with a debug log and returns 'Unknown' as the activity type.

Next steps:
- Implement the new activity types in this library
- Or potentially refactor react-native project to use more common library: react-native-health